### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -242,6 +242,7 @@ require("lspconfig")["sumneko_lua"].setup {
       diagnostics = { globals = { "vim" } },
       workspace = {
         library = vim.api.nvim_get_runtime_file("", true),
+        checkThirdParty = false,
       },
       telemetry = {
         enable = false,


### PR DESCRIPTION
Fix `lua-language-server` messages by disabling 3rd party checks. See https://github.com/neovim/nvim-lspconfig/issues/1700#issuecomment-1033127328.